### PR TITLE
Adding reference to reprap wiki for NEMA 17

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,9 @@ Z-axis motors with larger ones. I suggest 48 mm NEMA 17
 motors, as they are quite a bit larger than the OEM ones
 but still fit well inside the frame.
 
+There is a list of commonly used NEMA 17 motors available
+from [reprap wiki](http://reprap.org/wiki/NEMA_17_Stepper_motor).
+
 Wiring-wise it is actually a lot of fiddle work. For me
 the wiring was blue/black cross-paired and the outer two
 wires being normally connected.

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ motors, as they are quite a bit larger than the OEM ones
 but still fit well inside the frame.
 
 There is a list of commonly used NEMA 17 motors available
-from [reprap wiki](http://reprap.org/wiki/NEMA_17_Stepper_motor).
+from the [reprap wiki](http://reprap.org/wiki/NEMA_17_Stepper_motor).
 
 Wiring-wise it is actually a lot of fiddle work. For me
 the wiring was blue/black cross-paired and the outer two


### PR DESCRIPTION
I think it's worth adding some reference to the reprap wiki to make it easier in deciding which to buy as it contains more details on the specification.